### PR TITLE
feat: Add Share and Download Contact Quick Actions

### DIFF
--- a/public/contact.vcf
+++ b/public/contact.vcf
@@ -1,0 +1,10 @@
+BEGIN:VCARD
+VERSION:3.0
+N:Adarkwah;King;;;
+FN:King Adarkwah
+ORG:KingMadeIt LLC
+TITLE:Senior Software Engineer + Designer
+TEL;TYPE=WORK,VOICE:(718) 724-4383
+EMAIL;TYPE=PREF,INTERNET:kingsley.adarkwah@gmail.com
+URL:https://meetking.vercel.app
+END:VCARD

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ const {bio, qrcodeUrl, typingText} = businessCard;
 
 const App = () => {
   return (
-     <main className='flex justify-center items-center w-full min-h-screen overflow-y-auto bg-[#101a23] mx-auto'>
+     <main className='flex relative justify-center items-center w-full min-h-screen overflow-y-auto bg-[#101a23] mx-auto'>
       <motion.div {...slideUp} className="transform-gpu">
         <GlassCard className="align-center space-y-4 w-full">
           <About bio={bio} />

--- a/src/components/DownloadContact.tsx
+++ b/src/components/DownloadContact.tsx
@@ -1,0 +1,14 @@
+import { RxDownload } from "react-icons/rx";
+
+const DownloadContact = () => {
+  return (
+    <a
+      href="/contact.vcf"
+      download
+      className="inline-block line-height-0 rounded-full text-white/70 shadow-lg hover:text-white transition z-50">
+      <RxDownload className="h-5 w-5 md:w-6 md:h-6" />
+    </a>
+  );
+};
+
+export default DownloadContact;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,16 +2,19 @@ import TypewriterLoop, { type TypewriterSequence } from "./kokonut-ui/Typewriter
 import { slideRight } from "../lib/data";
 import { motion } from "motion/react";
 import {memo} from 'react';
+import { DownloadContact, ShareContact } from ".";
 
 const Footer = ({typingText}: {typingText: TypewriterSequence[]}) => {
   return (
-    <motion.footer {...slideRight} className='will-change-transform w-full mt-4 p-4 pb-0 border-t-1 border-white/10'>
+    <motion.footer {...slideRight} className='flex will-change-transform w-full mt-4 p-4 pb-0 border-t-1 border-white/10'>
+        <DownloadContact />
         <TypewriterLoop 
           typingSpeed={100}
           startDelay={1500}
           loopDelay={2000}
           sequences={typingText} 
         />
+        <ShareContact />
     </motion.footer>
   )
 }

--- a/src/components/Qrcode.tsx
+++ b/src/components/Qrcode.tsx
@@ -6,7 +6,7 @@ import { scaleIn } from '../lib/data'
 
 const Qrcode = ({url}: {url: string}) => {
   return (
-    <motion.div {...scaleIn} className='transform-gpu flex w-[128px] h-[128px] mt-2 mb-4 rounded-sm justify-center items-center border-3 border-cyan-300/30 animate-pulse'>
+    <motion.div {...scaleIn} className='transform-gpu flex w-[128px] h-[128px] mt-2 mb-4 rounded-sm justify-center items-center border-3 border-cyan-300/30'>
       <QRCodeSVG  className='qrcode' opacity='0.7' value={url}/>
     </motion.div>
   )

--- a/src/components/ShareContact.tsx
+++ b/src/components/ShareContact.tsx
@@ -1,0 +1,34 @@
+import { GoShare } from "react-icons/go";
+import {shareContactInfo} from "../lib/data";
+
+const { title, text, url } = shareContactInfo;
+
+const ShareContact = () => {
+  const handleShare = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title,
+          text,
+          url
+        });
+      } catch (error) {
+        console.error("Error sharing:", error);
+      }
+    } else {
+      alert("Sharing is not supported on this device.");
+    }
+  };
+
+  return (
+    <button
+      onClick={handleShare}
+      className="text-white/70 hover:text-blue-500 transition z-50 cursor-pointer"
+      aria-label="Share"
+    >
+      <GoShare className="w-5 h-5 md:w-6 md:h-6" />
+    </button>
+  );
+};
+
+export default ShareContact;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -5,6 +5,9 @@ import Qrcode from "./Qrcode";
 import Footer from "./Footer";
 import TypewriterLoop from "./kokonut-ui/TypewriterLoop";
 import MatrixText from "./kokonut-ui/MatrixText";
+import DownloadContact from './DownloadContact';
+import ShareContact from "./ShareContact";
+
 export {
-    GlassCard, About, Qrcode, ContactLinks, Footer, TypewriterLoop, MatrixText
+    GlassCard, About, Qrcode, ContactLinks, Footer, TypewriterLoop, MatrixText, DownloadContact, ShareContact
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -92,3 +92,9 @@ export const staggerParent = {
     },
   },
 };
+
+export const shareContactInfo: {title: string, text: string, url: string} = {
+  title: "KingMadeIt",
+  text: "Check out King's business card for contact details!",
+  url: "https://meetking.vercel.app",
+}


### PR DESCRIPTION
This PR introduces two floating action buttons to enhance user interaction on the digital business card:

1. Download Contact (.vcf)
2. Share Profile (Web Share API)

**Changes:**

- Created a new QuickActions component housing both actions.
- Implemented .vcf download via a semantic <a> element with proper download attribute.
- Integrated the Web Share API to trigger the native share sheet on supported devices.
- Styled both actions using Tailwind CSS for mobile-first UI.


**Why:**
This improves mobile UX by allowing users to:
- Easily save contact info to their phone contacts
- Quickly share the business card via native system options (e.g., iMessage, AirDrop, WhatsApp)

